### PR TITLE
Fix: support TypeScript node 16 module resolution

### DIFF
--- a/create-package-files
+++ b/create-package-files
@@ -1,12 +1,25 @@
 #!/bin/bash
+
+# Create CommonJS package.json
 cat >dist/cjs/package.json <<!EOF
 {
     "type": "commonjs"
 }
 !EOF
 
+# Write typings to support Node16 module resolution 
+cat >dist/cjs/index.d.ts <<!EOF
+export * from '../types';
+!EOF
+
+# Create ESM package.json
 cat >dist/esm/package.json <<!EOF
 {
     "type": "module"
 }
+!EOF
+
+# Write typings to support Node16 module resolution 
+cat >dist/esm/index.d.ts <<!EOF
+export * from '../types';
 !EOF

--- a/dist/cjs/index.d.ts
+++ b/dist/cjs/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../types';

--- a/dist/esm/index.d.ts
+++ b/dist/esm/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../types';


### PR DESCRIPTION
Write `index.d.ts` type definition files in the dist folders, that export all types from the right directory. This fixes projects where `acebase-server` is imported by an app using TypeScript with Node16 module resolution.