### PR TITLE
Exclude dev files in published npm packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+# Exclude dev files from npm package
+src
+dist/**/*.js.map
+spec
+.eslintrc
+tsconfig*.*
+create-package-files


### PR DESCRIPTION
Don't publish TypeScript source, `.js.map` files, tests and other development files in npm packages