### PR TITLE
Bump acebase and acebase-core dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "author": "Ewout Stortenbeker <me@appy.one> (http://appy.one)",
   "license": "MIT",
   "dependencies": {
-    "acebase": "^1.24.1",
-    "acebase-core": "^1.22.2",
+    "acebase": "^1.24.2",
+    "acebase-core": "^1.22.3",
     "express": "^4.17.1",
     "socket.io": "^4.5.0",
     "swagger-jsdoc": "^6.1.0",


### PR DESCRIPTION
Fixes https://github.com/appy-one/acebase/issues/152 (de)serialization of BigInts to/from binary