### PR TITLE
Attach to an existing server. Route prefixing (#49)

### DIFF
--- a/src/routes/webmanager.ts
+++ b/src/routes/webmanager.ts
@@ -8,7 +8,7 @@ export const addRoutes = (env: RouteInitEnvironment) => {
 
     // Add redirect from root to webmanager
     env.app.get('/', (req, res) => {
-        res.redirect(webManagerDir);
+        res.redirect(env.root + webManagerDir.slice(1));
     });
 
     // Serve static files from webmanager directory

--- a/src/routes/webmanager.ts
+++ b/src/routes/webmanager.ts
@@ -8,7 +8,7 @@ export const addRoutes = (env: RouteInitEnvironment) => {
 
     // Add redirect from root to webmanager
     env.app.get('/', (req, res) => {
-        res.redirect(env.root + webManagerDir.slice(1));
+        res.redirect(env.rootPath + webManagerDir.slice(1));
     });
 
     // Serve static files from webmanager directory

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,7 +63,7 @@ export class AceBaseServer extends SimpleEventEmitter {
      * Gets the url the server is running at
      */
     get url() {
-        return `http${this.config.https.enabled ? 's' : ''}://${this.config.host}:${this.config.port}${this.config.route}`;
+        return `http${this.config.https.enabled ? 's' : ''}://${this.config.host}:${this.config.port}${this.config.rootPath}`;
     }
 
     readonly debug: DebugLogger;
@@ -173,7 +173,7 @@ export class AceBaseServer extends SimpleEventEmitter {
             db: db as AceBase & { api: Api },
             authDb,
             app: router,
-            rootPath: this.config.route,
+            rootPath: this.config.rootPath,
             debug: this.debug,
             securityRef,
             authRef,
@@ -231,7 +231,7 @@ export class AceBaseServer extends SimpleEventEmitter {
         addWebsocketServer(routeEnv);
 
         // Register all the routes for the app
-        app.use(this.config.route, router);
+        app.use(this.config.rootPath, router);
 
         // Last but not least, add 404 handler
         // DISABLED because it causes server extension routes through server.extend (see above) not be be executed

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -179,9 +179,9 @@ export type AceBaseServerSettings = Partial<{
     server: Server;
 
     /**
-     * Root for the AceBase routes
+     * Root path for the AceBase routes
      */
-    route: string;
+    rootPath : string;
 
     /** 
      * settings that define if and how authentication is used 
@@ -229,7 +229,7 @@ export class AceBaseServerConfig {
     readonly allowOrigin: string = '*';
     readonly https: AceBaseServerHttpsConfig;
     readonly server?: Server;
-    readonly route: string = "/";
+    readonly rootPath: string = "/";
     readonly auth: AceBaseServerAuthenticationSettings;
     readonly email: AceBaseServerEmailSettings;
     readonly transactions: AceBaseServerTransactionSettings;
@@ -243,9 +243,9 @@ export class AceBaseServerConfig {
         if (typeof settings.port === 'number') { this.port = settings.port; }
         if (typeof settings.path === 'string') { this.path = settings.path; }
         if (typeof settings.server === 'object') { this.server = settings.server; }
-        if (typeof settings.route === 'string') { 
-            this.route = settings.route; 
-            if (!this.route.endsWith("/")) this.route += "/";
+        if (typeof settings.rootPath === 'string') { 
+            this.rootPath = settings.rootPath; 
+            if (!this.rootPath.endsWith("/")) this.rootPath += "/";
         }
         this.https = new AceBaseServerHttpsConfig(settings.https);
         this.auth = new AceBaseServerAuthenticationSettings(settings.authentication);

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,6 +1,7 @@
 import { AceBaseStorageSettings } from 'acebase';
 import { readFileSync } from 'fs';
 import { AceBaseServerEmailSettings } from './email';
+import { Server } from 'http';
 
 export type AceBaseServerHttpsSettings = { 
     enabled?: boolean;
@@ -172,6 +173,11 @@ export type AceBaseServerSettings = Partial<{
      */
     https: AceBaseServerHttpsSettings;
 
+    /**
+     * Provide your own server for AceBase to use
+     */
+    server: Server;
+
     /** 
      * settings that define if and how authentication is used 
      */
@@ -217,6 +223,7 @@ export class AceBaseServerConfig {
     readonly maxPayloadSize: string = '10mb';
     readonly allowOrigin: string = '*';
     readonly https: AceBaseServerHttpsConfig;
+    readonly server?: Server;
     readonly auth: AceBaseServerAuthenticationSettings;
     readonly email: AceBaseServerEmailSettings;
     readonly transactions: AceBaseServerTransactionSettings;
@@ -229,6 +236,7 @@ export class AceBaseServerConfig {
         if (typeof settings.host === 'string') { this.host = settings.host; }
         if (typeof settings.port === 'number') { this.port = settings.port; }
         if (typeof settings.path === 'string') { this.path = settings.path; }
+        if (typeof settings.server === 'object') { this.server = settings.server; }
         this.https = new AceBaseServerHttpsConfig(settings.https);
         this.auth = new AceBaseServerAuthenticationSettings(settings.authentication);
         if (typeof settings.maxPayloadSize === 'string') { this.maxPayloadSize = settings.maxPayloadSize; }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -178,6 +178,11 @@ export type AceBaseServerSettings = Partial<{
      */
     server: Server;
 
+    /**
+     * Root for the AceBase routes
+     */
+    route: string;
+
     /** 
      * settings that define if and how authentication is used 
      */
@@ -224,6 +229,7 @@ export class AceBaseServerConfig {
     readonly allowOrigin: string = '*';
     readonly https: AceBaseServerHttpsConfig;
     readonly server?: Server;
+    readonly route: string = "/";
     readonly auth: AceBaseServerAuthenticationSettings;
     readonly email: AceBaseServerEmailSettings;
     readonly transactions: AceBaseServerTransactionSettings;
@@ -237,6 +243,10 @@ export class AceBaseServerConfig {
         if (typeof settings.port === 'number') { this.port = settings.port; }
         if (typeof settings.path === 'string') { this.path = settings.path; }
         if (typeof settings.server === 'object') { this.server = settings.server; }
+        if (typeof settings.route === 'string') { 
+            this.route = settings.route; 
+            if (!this.route.endsWith("/")) this.route += "/";
+        }
         this.https = new AceBaseServerHttpsConfig(settings.https);
         this.auth = new AceBaseServerAuthenticationSettings(settings.authentication);
         if (typeof settings.maxPayloadSize === 'string') { this.maxPayloadSize = settings.maxPayloadSize; }

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -11,6 +11,7 @@ import type { PathBasedRules } from '../rules';
 import { DatabaseLog } from '../logger';
 
 export interface RouteInitEnvironment {
+    root: string;
     server: HttpServer | SecureHttpServer;
     app: HttpApp;
     config: AceBaseServerConfig;

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -11,7 +11,7 @@ import type { PathBasedRules } from '../rules';
 import { DatabaseLog } from '../logger';
 
 export interface RouteInitEnvironment {
-    root: string;
+    rootPath: string;
     server: HttpServer | SecureHttpServer;
     app: HttpApp;
     config: AceBaseServerConfig;

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -24,3 +24,11 @@ export const createApp = (settings: { trustProxy: boolean; maxPayloadSize: strin
 
     return app as HttpApp;
 }
+
+/**
+ * Creates an express router
+ * @returns 
+ */
+export const createRouter = () => {
+    return createExpress.Router();
+}

--- a/src/websocket/socket.io.ts
+++ b/src/websocket/socket.io.ts
@@ -44,7 +44,7 @@ export const createServer = (env: RouteInitEnvironment) => {
         pingInterval: 5000,     // socket.io 2.x default is 25000
         pingTimeout: 5000,      // socket.io 2.x default is 5000, 3.x default = 20000
         maxHttpBufferSize: maxPayloadBytes,
-        path: env.root + "ws",
+        path: env.rootPath + "ws",
 
         // Allow socket.io 2.x clients (using engine.io 3.x):
         allowEIO3: true,

--- a/src/websocket/socket.io.ts
+++ b/src/websocket/socket.io.ts
@@ -44,6 +44,7 @@ export const createServer = (env: RouteInitEnvironment) => {
         pingInterval: 5000,     // socket.io 2.x default is 25000
         pingTimeout: 5000,      // socket.io 2.x default is 5000, 3.x default = 20000
         maxHttpBufferSize: maxPayloadBytes,
+        path: env.root + "ws",
 
         // Allow socket.io 2.x clients (using engine.io 3.x):
         allowEIO3: true,

--- a/src/websocket/socket.io.ts
+++ b/src/websocket/socket.io.ts
@@ -44,7 +44,7 @@ export const createServer = (env: RouteInitEnvironment) => {
         pingInterval: 5000,     // socket.io 2.x default is 25000
         pingTimeout: 5000,      // socket.io 2.x default is 5000, 3.x default = 20000
         maxHttpBufferSize: maxPayloadBytes,
-        path: env.rootPath + "ws",
+        path: env.rootPath + "socket.io",
 
         // Allow socket.io 2.x clients (using engine.io 3.x):
         allowEIO3: true,


### PR DESCRIPTION
Some changes that were discussed in #49 were made here. I added a `server` option that accepts an `http` server and a `route` option which overrides the base route for AceBase.

For example (modified `test.ts`):
```ts
// Starts a test server for debugging sessions
import { createServer } from 'http';
import { AceBaseServer } from './server';

// Make sure development environment is set
process.env.NODE_ENV = 'development';

const server = createServer();
server.listen(8080);

const base = new AceBaseServer('default', { logLevel: 'verbose', route: '/acebase', host: 'localhost', port: 8080, server, path: '.' });
base.once('ready', () => {
    console.log(`Ready to debug!`);
});

process.on("SIGINT", () => server.close());
```

It will use `server` as it's server and listen on `http://localhost:8080/acebase`. Socket.IO will listen on `http://localhost:8080/acebase/ws`.

## IMPORTANT! BREAKING CHANGE!
The default path for socket.io is now `http://localhost:8080/ws`! (Previously was `http://localhost:8080/socket.io`). In general the path now is `http://localhost:8080/` + **route** + `/ws`.

AceBase didn't specify any path before for `Socket.IO` to use, therefore it fellback to `/socket.io`. We might want to change the new version to `http://localhost:8080/` + **route** + `/socket.io` to preserve compatibility. But since this PR needs client changes anyway I thought using `ws` would be nicer. Also I've seen some comments in the code about supporting other web socket libraries. I that case `/ws` would be more future proof path than `/socket.io`.

I haven't started working on the client yet. Let me know you thoughts about this PR. What shall we do with `socket.io`? Are the other changes ok? I've also fixed the redirect to `webmanager`. Are there any other path dependent parts that I might have missed?