### PR TITLE
Fix Bundling Issues

### DIFF
--- a/src/routes/meta-info.ts
+++ b/src/routes/meta-info.ts
@@ -1,7 +1,7 @@
 import { RouteInitEnvironment, RouteRequest } from '../shared/env';
 import * as os from 'os';
-//@ts-ignore
-import { version } from "../../../package.json";
+// @ts-ignore We need it here, so TypeScript doesn't get mad about the file in not being in the source directory
+import meta from "../../../package.json" assert { type: "json" };
 
 export type RequestQuery = null;
 export type RequestBody = null;
@@ -17,7 +17,7 @@ export const addRoute = (env: RouteInitEnvironment) => {
     env.app.get(`/info/${env.db.name}`, (req: Request, res) => {
 
         const info = {
-            version, // Loaded from package.json
+            version: meta.version, // Loaded from package.json
             time: Date.now(), 
             process: process.pid
         };

--- a/src/routes/meta-info.ts
+++ b/src/routes/meta-info.ts
@@ -1,8 +1,7 @@
 import { RouteInitEnvironment, RouteRequest } from '../shared/env';
-import { readFileSync } from 'fs';
-import { packageRootPath } from '../shared/rootpath';
-import { join as joinPaths } from 'path';
 import * as os from 'os';
+//@ts-ignore
+import { version } from "../../../package.json";
 
 export type RequestQuery = null;
 export type RequestBody = null;
@@ -14,17 +13,11 @@ export type ResponseBody = {
 export type Request = RouteRequest<RequestQuery, RequestBody, ResponseBody>;
 
 export const addRoute = (env: RouteInitEnvironment) => {
-
-    // Read server version from package.json
-    const filePath = joinPaths(packageRootPath, '/package.json');
-    const json = readFileSync(filePath, 'utf-8');
-    const packageInfo = JSON.parse(json);
-
     // Add info endpoint
     env.app.get(`/info/${env.db.name}`, (req: Request, res) => {
 
         const info = {
-            version: packageInfo.version, // Loaded from package.json
+            version, // Loaded from package.json
             time: Date.now(), 
             process: process.pid
         };

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,11 +16,9 @@ import addCorsMiddleware from './middleware/cors';
 import addAuthenticionRoutes from './routes/auth';
 import setupAuthentication from './auth';
 import addDataRoutes from './routes/data';
-import addDocsRoute from './routes/docs';
 import addWebManagerRoutes from './routes/webmanager';
 import addMetadataRoutes from './routes/meta';
 import add404Middleware from './middleware/404';
-import addSwaggerMiddleware from './middleware/swagger';
 import addCacheMiddleware from './middleware/cache';
 import { DatabaseLog } from './logger';
 
@@ -201,10 +199,10 @@ export class AceBaseServer extends SimpleEventEmitter {
         addMetadataRoutes(routeEnv);
 
         // If environment is development, add API docs
-        if (process.env.NODE_ENV?.trim?.() === 'development') {
+        if (process.env.NODE_ENV === 'development') {
             this.debug.warn('DEVELOPMENT MODE: adding API docs endpoint at /docs');
-            addDocsRoute(routeEnv);
-            addSwaggerMiddleware(routeEnv);
+            (await import("./routes/docs")).addRoute(routeEnv);
+            (await import("./middleware/swagger")).addMiddleware(routeEnv);
         }
 
         // Add data endpoints

--- a/src/server.ts
+++ b/src/server.ts
@@ -199,7 +199,7 @@ export class AceBaseServer extends SimpleEventEmitter {
         addMetadataRoutes(routeEnv);
 
         // If environment is development, add API docs
-        if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'development ') {
+        if (process.env.NODE_ENV && process.env.NODE_ENV.trim() === 'development') {
             this.debug.warn('DEVELOPMENT MODE: adding API docs endpoint at /docs');
             (await import("./routes/docs")).addRoute(routeEnv);
             (await import("./middleware/swagger")).addMiddleware(routeEnv);

--- a/src/server.ts
+++ b/src/server.ts
@@ -199,7 +199,7 @@ export class AceBaseServer extends SimpleEventEmitter {
         addMetadataRoutes(routeEnv);
 
         // If environment is development, add API docs
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'development ') {
             this.debug.warn('DEVELOPMENT MODE: adding API docs endpoint at /docs');
             (await import("./routes/docs")).addRoute(routeEnv);
             (await import("./middleware/swagger")).addMiddleware(routeEnv);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         "outDir": "./dist/esm",
         "moduleResolution": "node",
         "target": "es2020",
-        "pretty": true
+        "pretty": true,
+        "resolveJsonModule": true,
     },
     "include": [
         "./src"


### PR DESCRIPTION
I use [vite](https://github.com/vitejs/vite/) to bundle my project into a single file when building for production. `acebase-server` is currently not suitable for such builds.

After some investigation, I found out that `swagger` completely breaks in single-file builds. I thought it shouldn't be used in production mode. However, it's still gets bundled increasing file size by a factor for TWO! To solve this problem, I've changed docs imports to dynamic ones and simplified environment condition to be recognized by bundler. (I still needed to do `replace({"process.env.NODE_ENV": '"production"'})` with `@rollup/plugin-node-resolve` though...)

The second problem was dynamically loaded `package.json` file which is obviously not present when `acebase-server` module is embedded into an application. To solve this we can use JSON imports from Typescript. This way during bundling the JSON data will be inlined properly. Btw, I did a little hack with `@ts-ignore` there because TypeScript got mad at the file not being at the source root (`./src`). It is still miles better that trying to load `package.json` from the filesystem, and crashing if it's not present.