### PR TITLE
Use ESM build when `import`ed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     }


### PR DESCRIPTION
@Azarattum this might be the reason Vite was using the CommonJS build, `import`ing of ESM build was temporarily disabled