### PR TITLE
`rootPath` setting improvements

### DIFF
--- a/src/routes/auth-signin.yaml
+++ b/src/routes/auth-signin.yaml
@@ -63,8 +63,8 @@
                   - username
                   - password
                 example:
-                  method: username
-                  username: user
+                  method: account
+                  username: admin
                   password: sup3rs3cr3t
               - type: object
                 properties:

--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -24,8 +24,10 @@ export const addRoute = (env: RouteInitEnvironment) => {
                     email: 'me@appy.one',
                     url: 'https://github.com/appy-one/acebase-server'
                 },
-                // servers: [`http://${config.server.host}:${config.server.port}`]
             },
+            servers: [
+                { url: `http${env.config.https?.enabled ? 's' : ''}://${env.config.host}:${env.config.port}${env.config.rootPath ? `/${env.config.rootPath}` : ''}` }
+            ],
             tags: [{
                 name: 'auth',
                 description: 'User authentication endpoints'

--- a/src/routes/webmanager.ts
+++ b/src/routes/webmanager.ts
@@ -4,16 +4,16 @@ import { join as joinPaths } from 'path'
 
 export const addRoutes = (env: RouteInitEnvironment) => {
 
-    const webManagerDir = `/webmanager/`;
+    const webManagerDir = `webmanager`;
 
     // Add redirect from root to webmanager
     env.app.get('/', (req, res) => {
-        res.redirect(env.rootPath + webManagerDir.slice(1));
+        res.redirect(`/${env.rootPath ? `${env.rootPath}/` : ''}${webManagerDir}/`);
     });
 
     // Serve static files from webmanager directory
-    env.app.get(`${webManagerDir}*`, (req, res) => {
-        const filePath = req.path.slice(webManagerDir.length);
+    env.app.get(`/${webManagerDir}/*`, (req, res) => {
+        const filePath = req.path.slice(webManagerDir.length + 2);
         const assetsPath = joinPaths(packageRootPath, '/webmanager');
         if (filePath.length === 0) {
             // Send default file

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { addWebsocketServer } from './websocket';
 import { RouteInitEnvironment } from './shared/env';
 import { ConnectedClient } from './shared/clients';
 import { AceBase, AceBaseLocalSettings, AceBaseStorageSettings } from 'acebase';
-import { createServer, Server } from 'http';
+import { createServer } from 'http';
 import { createServer as createSecureServer } from 'https';
 import { OAuth2Provider } from './oauth-providers/oauth-provider';
 import oAuth2Providers from './oauth-providers';
@@ -61,7 +61,7 @@ export class AceBaseServer extends SimpleEventEmitter {
      * Gets the url the server is running at
      */
     get url() {
-        return `http${this.config.https.enabled ? 's' : ''}://${this.config.host}:${this.config.port}${this.config.rootPath}`;
+        return `http${this.config.https.enabled ? 's' : ''}://${this.config.host}:${this.config.port}/${this.config.rootPath}`;
     }
 
     readonly debug: DebugLogger;
@@ -231,7 +231,7 @@ export class AceBaseServer extends SimpleEventEmitter {
         addWebsocketServer(routeEnv);
 
         // Register all the routes for the app
-        app.use(this.config.rootPath, router);
+        app.use(`/${this.config.rootPath}`, router);
 
         // Last but not least, add 404 handler
         // DISABLED because it causes server extension routes through server.extend (see above) not be be executed

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -240,7 +240,7 @@ export class AceBaseServerConfig {
     readonly allowOrigin: string = '*';
     readonly https: AceBaseServerHttpsConfig;
     readonly server?: Server;
-    readonly rootPath: string = "/";
+    readonly rootPath: string = '';
     readonly auth: AceBaseServerAuthenticationSettings;
     readonly email: AceBaseServerEmailSettings;
     readonly transactions: AceBaseServerTransactionSettings;
@@ -257,8 +257,7 @@ export class AceBaseServerConfig {
         if (typeof settings.path === 'string') { this.path = settings.path; }
         if (typeof settings.server === 'object') { this.server = settings.server; }
         if (typeof settings.rootPath === 'string') { 
-            this.rootPath = settings.rootPath; 
-            if (!this.rootPath.endsWith("/")) this.rootPath += "/";
+            this.rootPath = settings.rootPath.replace(/^\/|\/$/g, '');
         }
         this.https = new AceBaseServerHttpsConfig(settings.https);
         this.auth = new AceBaseServerAuthenticationSettings(settings.authentication);

--- a/src/start.ts
+++ b/src/start.ts
@@ -18,7 +18,8 @@ const dbname = getVariable('DBNAME', 'default');
 const host = getVariable('HOST', 'localhost'); // '0.0.0.0'
 const port = +getVariable('PORT', 3000);
 const ipcPort = +getVariable('IPC_PORT', 0);
-const options: AceBaseServerSettings = { host, port, path };
+const rootPath = getVariable('ROOT_PATH', '');
+const options: AceBaseServerSettings = { host, port, path, rootPath };
 if (ipcPort > 0) {
     const role = getVariable('IPC_ROLE');
     if (!['master','worker'].includes(role)) {

--- a/src/websocket/socket.io.ts
+++ b/src/websocket/socket.io.ts
@@ -44,7 +44,7 @@ export const createServer = (env: RouteInitEnvironment) => {
         pingInterval: 5000,     // socket.io 2.x default is 25000
         pingTimeout: 5000,      // socket.io 2.x default is 5000, 3.x default = 20000
         maxHttpBufferSize: maxPayloadBytes,
-        path: env.rootPath + "socket.io",
+        path: `/${env.rootPath ? `${env.rootPath}/` : ''}socket.io`,
 
         // Allow socket.io 2.x clients (using engine.io 3.x):
         allowEIO3: true,


### PR DESCRIPTION
* allow `rootPath` setting to be specified with or without leading/trailing slashes - uses _slashless_ values internally to avoid confusion
* adds support to the Swagger documentation endpoints
* adds a new startup argument / environment var `ROOT_PATH` to be specified