### PR TITLE
Fix: meta info issue

### DIFF
--- a/build-vars.js
+++ b/build-vars.js
@@ -1,4 +1,4 @@
-// Executed by npm "build" and "prepare" scripts
+// Executed by npm "prepack" script
 const { readFileSync, writeFileSync } = require('fs');
 const packageInfo = require('./package.json');
 

--- a/build-vars.js
+++ b/build-vars.js
@@ -1,0 +1,11 @@
+// Executed by npm "build" and "prepare" scripts
+const { readFileSync, writeFileSync } = require('fs');
+const packageInfo = require('./package.json');
+
+const files = ['./dist/cjs/routes/meta-info.js', './dist/esm/routes/meta-info.js'];
+files.forEach(file => {
+    let content = readFileSync(file, 'utf8');
+    content = content.replace(/%SERVER_VERSION%/g, packageInfo.version);
+    writeFileSync(file, content, 'utf8');
+    console.log(`Replaced variable %SERVER_VERSION% with ${packageInfo.version} in ${file}`);
+});

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "test": "set NODE_ENV=development && npm run start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "build": "npm run build:clean && npm run build:esm && npm run build:cjs && npm run build:packages && echo Done!",
+    "build": "npm run build:clean && npm run build:esm && npm run build:cjs && npm run build:packages && npm run build:vars && echo Done!",
     "build:clean": "rm -fr dist/*",
     "build:esm": "tsc -p tsconfig.json && npx tsc-esm-fix ---target='dist/esm'",
     "build:cjs": "tsc -p tsconfig-cjs.json",
     "build:packages": "bash ./create-package-files",
-    "npmfix": "echo 'Regenerating package-lock.json...' && npm i --package-lock-only"
+    "build:vars": "node ./build-vars.js",
+    "prepare": "npm run build:vars"
   },
   "keywords": [
     "database",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "test": "set NODE_ENV=development && npm run start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "build": "npm run build:clean && npm run build:esm && npm run build:cjs && npm run build:packages && npm run build:vars && echo Done!",
+    "build": "npm run build:clean && npm run build:esm && npm run build:cjs && npm run build:packages && echo Done!",
     "build:clean": "rm -fr dist/*",
     "build:esm": "tsc -p tsconfig.json && npx tsc-esm-fix ---target='dist/esm'",
     "build:cjs": "tsc -p tsconfig-cjs.json",
     "build:packages": "bash ./create-package-files",
     "build:vars": "node ./build-vars.js",
-    "prepare": "npm run build:vars"
+    "prepack": "npm run build:vars"
   },
   "keywords": [
     "database",

--- a/src/routes/meta-info.ts
+++ b/src/routes/meta-info.ts
@@ -1,8 +1,6 @@
 import { RouteInitEnvironment, RouteRequest } from '../shared/env';
 import * as os from 'os';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore path to package.json is different in builds
-import meta from '../../../package.json' assert { type: 'json' };
+const SERVER_VERSION = '%SERVER_VERSION%'; // Loaded from package.json by npm scripts
 
 export type RequestQuery = null;
 export type RequestBody = null;
@@ -18,7 +16,7 @@ export const addRoute = (env: RouteInitEnvironment) => {
     env.app.get(`/info/${env.db.name}`, (req: Request, res) => {
 
         const info = {
-            version: meta.version, // Loaded from package.json
+            version: SERVER_VERSION,
             time: Date.now(),
             process: process.pid,
         };


### PR DESCRIPTION
Fixes  #66 by running a script in npm's prepack event hook that replaces the `%SERVER_VERSION%` variable with the `version` in `package.json`. This eliminates the need to `import` or `require` from `package.json` in the `meta-info` endpoint at runtime.