### PR TITLE
Fix error update/set error types in Swagger docs

### DIFF
--- a/build-vars.js
+++ b/build-vars.js
@@ -3,7 +3,8 @@ const { readFileSync, writeFileSync } = require('fs');
 const { execSync } = require('child_process');
 const packageInfo = require('./package.json');
 
-const files = ['./dist/cjs/routes/meta-info.js', './dist/esm/routes/meta-info.js'];
+const sources = ['routes/meta-info', 'routes/docs'];
+const files = sources.reduce((all ,file) => (all.push(`./dist/cjs/${file}.js`, `./dist/esm/${file}.js`), all), []);
 files.forEach(file => {
     const originalContent = readFileSync(file, 'utf8');
     content = originalContent.replace(/%SERVER_VERSION%/g, packageInfo.version);

--- a/src/routes/data-set.yaml
+++ b/src/routes/data-set.yaml
@@ -49,20 +49,20 @@
                   type: boolean
                   example: true
       400:
-        description: Returns "400 Bad Request" if the sent value is incorrect
+        description: Returns "400 Bad Request if the sent value is incorrect
         content:
           'application/json':
             schema:
               $ref: '#/components/schemas/Error'
-              example:
-                code: invalid_serialized_value
-                message: The sent value is not properly serialized
+            example:
+              code: invalid_serialized_value
+              message: The sent value is not properly serialized
       403:
         description: Returns "403 Forbidden" if the signed in user is not allowed to write to the target path
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/Error'
+              $ref: '#/components/schemas/RuleValidationError'
       422:
         description: Returns "422 Unprocessable Entity" if schema validation for the sent value failed.
         content:

--- a/src/routes/data-update.yaml
+++ b/src/routes/data-update.yaml
@@ -54,15 +54,15 @@
           'application/json':
             schema:
               $ref: '#/components/schemas/Error'
-              example:
-                code: invalid_serialized_value
-                message: The sent value is not properly serialized
+            example:
+              code: invalid_serialized_value
+              message: The sent value is not properly serialized
       403:
         description: Returns "403 Forbidden" if the signed in user is not allowed to write to the target path
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/Error'
+              $ref: '#/components/schemas/RuleValidationError'
       422:
         description: Returns "422 Unprocessable Entity" if schema validation for the sent value failed.
         content:

--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -18,7 +18,7 @@ export const addRoute = (env: RouteInitEnvironment) => {
             info: {
                 title: 'AceBase Server',
                 description: 'AceBase Server API endpoint documentation and test environment. This documentation is available on the server because it is running in development mode. To disable this, set your NODE_ENV environment variable to production. Many endpoints require you to authenticate using Bearer authentication. Use the _/auth/{dbname}/signin_ endpoint to obtain an access token, then click the _Authorize_ button and paste your token into the input field. For more information about AceBase, see GitHub',
-                version: '1.10.0',
+                version: '%SERVER_VERSION%', // Loaded from package.json by npm scripts
                 contact: {
                     name: 'AceBase API Support',
                     email: 'me@appy.one',
@@ -109,6 +109,13 @@ export const addRoute = (env: RouteInitEnvironment) => {
                         properties: {
                             code: { type: 'string', description: 'The string `"schema_validation_failed"`', example: 'schema_validation_failed' },
                             message: { type: 'string', description: 'The server error message', example: 'Property at path "path/property" is of the wrong type' },
+                        },
+                    },
+                    RuleValidationError: {
+                        type: 'object',
+                        properties: {
+                            code: { type: 'string', description: 'The string `"rule"`', example: 'rule' },
+                            message: { type: 'string', description: 'The server error message', example: 'write operation denied to path "path/property" by set rule' },
                         },
                     },
                     SerializedValue: {


### PR DESCRIPTION
This fixes the error types/examples for update/set operations in Swagger docs, also adds auto-update server version