### PR TITLE
Feature: "warn only" schema definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/acebase": {
-      "version": "1.28.5",
-      "resolved": "https://registry.npmjs.org/acebase/-/acebase-1.28.5.tgz",
-      "integrity": "sha512-zbmzbTaHBMDknQXayK7/D/lWBcMB4lxVQ48z0kxo1SZtfgXDzBEupmoyrTfQyuLFtS53UnIajlCkvz74bnimdw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/acebase/-/acebase-1.29.0.tgz",
+      "integrity": "sha512-BUNo73stR0BNxoKX1QJiz8xwz/K/yEHh7DRxNlsc2l/1QyEzFl97lRtf8dT+QQGHBBloiKW2YHjhpuOTikzrRQ==",
       "funding": [
         {
           "type": "GitHub sponsoring",
@@ -718,14 +718,14 @@
         }
       ],
       "dependencies": {
-        "acebase-core": "^1.26.2",
+        "acebase-core": "^1.27.1",
         "unidecode": "^0.1.8"
       }
     },
     "node_modules/acebase-core": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.2.tgz",
-      "integrity": "sha512-Pg/eAq48H3aqyIYmwQEEMNX42UQXjNUDydAbT8UOmC1Q90X2j/U3M1yrTLT6i6fkOIdTT1iIrR8UqMxAvyucbw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.27.1.tgz",
+      "integrity": "sha512-+yfjyzSWKLIFNk7PdpER3zK2J8b1C6mxVgnHGM5cjimO244OqDR4IvZ7wAfM88oWqK8AnZ0WhbgVl4xoWsfrhA==",
       "optionalDependencies": {
         "rxjs": ">= 5.x <= 7.x"
       }
@@ -3968,18 +3968,18 @@
       }
     },
     "acebase": {
-      "version": "1.28.5",
-      "resolved": "https://registry.npmjs.org/acebase/-/acebase-1.28.5.tgz",
-      "integrity": "sha512-zbmzbTaHBMDknQXayK7/D/lWBcMB4lxVQ48z0kxo1SZtfgXDzBEupmoyrTfQyuLFtS53UnIajlCkvz74bnimdw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/acebase/-/acebase-1.29.0.tgz",
+      "integrity": "sha512-BUNo73stR0BNxoKX1QJiz8xwz/K/yEHh7DRxNlsc2l/1QyEzFl97lRtf8dT+QQGHBBloiKW2YHjhpuOTikzrRQ==",
       "requires": {
-        "acebase-core": "^1.26.2",
+        "acebase-core": "^1.27.1",
         "unidecode": "^0.1.8"
       }
     },
     "acebase-core": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.2.tgz",
-      "integrity": "sha512-Pg/eAq48H3aqyIYmwQEEMNX42UQXjNUDydAbT8UOmC1Q90X2j/U3M1yrTLT6i6fkOIdTT1iIrR8UqMxAvyucbw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.27.1.tgz",
+      "integrity": "sha512-+yfjyzSWKLIFNk7PdpER3zK2J8b1C6mxVgnHGM5cjimO244OqDR4IvZ7wAfM88oWqK8AnZ0WhbgVl4xoWsfrhA==",
       "requires": {
         "rxjs": ">= 5.x <= 7.x"
       }

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "author": "Ewout Stortenbeker <me@appy.one> (http://appy.one)",
   "license": "MIT",
   "dependencies": {
-    "acebase": "^1.28.5",
-    "acebase-core": "^1.26.2",
+    "acebase": "^1.29.0",
+    "acebase-core": "^1.27.1",
     "express": "^4.17.1",
     "socket.io": "^4.5.0",
     "swagger-jsdoc": "^6.1.0",

--- a/src/routes/data-schema-set.ts
+++ b/src/routes/data-schema-set.ts
@@ -7,6 +7,7 @@ export type RequestBody = {
     action?: 'set'; // deprecated
     path: string;
     schema: string | Record<string, any>;
+    warnOnly?: boolean;
 };
 export type ResponseBody = { success: true }    // 200
     | { code: 'admin_only'; message: string }   // 403
@@ -20,8 +21,8 @@ export const addRoute = (env: RouteInitEnvironment) => {
         // defines a schema
         try {
             const data = req.body;
-            const { path, schema } = data;
-            await env.db.schema.set(path, schema);
+            const { path, schema, warnOnly = false } = data;
+            await env.db.schema.set(path, schema, warnOnly);
 
             res.contentType('application/json').send({ success: true });
         }

--- a/src/routes/data-schema-set.yaml
+++ b/src/routes/data-schema-set.yaml
@@ -32,6 +32,10 @@
                 type: string
                 description: When given, tests this schema definition against the passed value instead of ones defined in the database
                 example: "{ name: string, stats?: { size: number, created: Date, modified: Date, deleted?: Date } }"
+              warnOnly:
+                type: boolean
+                description: whether to issue warnings for failing schema checks instead of denying writes. This allows you to add schemas to an existing database and testdrive them without enforcing them yet. Default is `false`
+                example: false
             required:
             - path
             - schema


### PR DESCRIPTION
This enables one to introduce schema definitions to an existing database, but logs warnings instead of denying writes not conforming to the schema.