### PR TITLE
Feature: acebase-server CLI

### DIFF
--- a/bin/acebase-server.js
+++ b/bin/acebase-server.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+if (process.argv[2] === 'start') {
+    require('../dist/cjs/start');
+}
+else {
+    console.log(`[acebase-server CLI] uknown instruction. Did you mean "npx acebase-server start"?`);
+}

--- a/bin/acebase-server.js
+++ b/bin/acebase-server.js
@@ -4,5 +4,5 @@ if (process.argv[2] === 'start') {
     require('../dist/cjs/start');
 }
 else {
-    console.log(`[acebase-server CLI] uknown instruction. Did you mean "npx acebase-server start"?`);
+    console.log(`[acebase-server CLI] unknown instruction. Did you mean "npx acebase-server start"?`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
-        "acebase": "^1.28.5",
-        "acebase-core": "^1.26.2",
+        "acebase": "^1.29.0",
+        "acebase-core": "^1.27.1",
         "express": "^4.17.1",
         "socket.io": "^4.5.0",
         "swagger-jsdoc": "^6.1.0",
         "swagger-ui-express": "^4.3.0"
+      },
+      "bin": {
+        "acebase-server": "bin/acebase-server.js"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
       "types": "./dist/types/index.d.ts"
     }
   },
+  "bin": {
+    "acebase-server": "./bin/acebase-server.js"
+  },
   "private": false,
   "repository": "github:appy-one/acebase-server",
   "scripts": {


### PR DESCRIPTION
This adds a simple CLI script to allow starting up an AceBase server from the command-line with `npx acebase-server start ...`