### PR TITLE
Feature: add new socket IPC method for server clusters

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,62 +1,6 @@
-import { AceBase } from 'acebase';
-import { AceBaseServer } from './server';
-import { AceBaseServerSettings } from './settings';
-import * as cluster from 'cluster';
-import * as os from 'os';
-const numCPUs = 2; //os.cpus().length;
-
 /**
- * Node.js cluster example. You can use this as a reference how to create an AceBaseServer cluster using Node.js'
- * built-in cluster functionality.
  *
- * If you want to run a pm2 or cloud-based cluster instead, do NOT use this code.
- * To do that, see https://github.com/appy-one/acebase-ipc-server
+ * To run an AceBase server in a cluster and examples, please refer to this discussion:
+ * https://github.com/appy-one/acebase-server/discussions/83
  *
  */
-
-const dbname = 'default';
-const options: AceBaseServerSettings = { /* default options */ }; // Load from cluster.config.js!
-options.authentication = { enabled: false };
-options.https = { enabled: false };
-
-if (cluster.isMaster) {
-    // Startup master
-    console.log(`Starting database server cluster with ${numCPUs} workers`);
-    const master = new AceBase(dbname, options);
-    master.once('ready', () => {
-        console.log(`Master database server started on process ${process.pid}`);
-    });
-
-    for (let i = 0; i < numCPUs; i++) {
-        const worker = cluster.fork();
-        worker.on('disconnect', () => {
-            console.error(`worker ${worker.process.pid} disconnected`);
-        });
-        worker.on('message', (msg) => {
-            if (msg === 'acebase-server-shutdown') {
-                // We could handle shutdown message here to kill the worker safely, but we'll do it in the worker threads instead: see below
-                // worker.kill();
-            }
-        });
-    }
-
-    cluster.on('exit', (worker, code, signal) => {
-        console.error(`worker ${worker.process.pid} died`);
-    });
-}
-else {
-    console.log(`Worker ${process.pid} is running`);
-
-    const server = new AceBaseServer(dbname, options);
-    server.ready(() => {
-        console.log(`Worker database server started on process ${process.pid}`);
-    });
-    // Handle shutdown event to exit the worker process safely
-    server.on('shutdown', () => {
-        process.exit();
-    });
-    // Other option:
-    // process.on('acebase-server-shutdown', () => {
-    //     process.exit();
-    // });
-}

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,13 +114,13 @@ export class AceBaseServer extends SimpleEventEmitter {
         const dbOptions: Partial<AceBaseLocalSettings> = {
             logLevel: this.config.logLevel,
             info: 'realtime database server',
-            // NEW: Allow storage setting like AceBaseLocalSettings - could allow using other db backend (typed, but undocumented)
-            storage: this.config.storage || {
+            storage: {
                 path: this.config.path,
                 removeVoidProperties: true,
+                ipc: this.config.ipc,
+                ...this.config.storage, // Allow overriding storage settings - allows using other db backends (typed, but undocumented)
             },
             transactions: this.config.transactions,
-            ipc: this.config.ipc,
             sponsor: this.config.sponsor,
             logColors: this.config.logColors,
         };

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -213,7 +213,7 @@ export type AceBaseServerSettings = Partial<{
     /**
      * IPC settings for pm2 or cloud-based clusters. BETA stage, see https://github.com/appy-one/acebase-ipc-server
      */
-    ipc: IPCClientSettings;
+    ipc: IPCClientSettings | 'socket';
 
     /**
      * Allows overriding of default storage settings used by the database. ALPHA stage
@@ -253,7 +253,7 @@ export class AceBaseServerConfig {
     readonly auth: AceBaseServerAuthenticationSettings;
     readonly email: AceBaseServerEmailSettings;
     readonly transactions: AceBaseServerTransactionSettings;
-    readonly ipc: IPCClientSettings;
+    readonly ipc: AceBaseServerSettings['ipc'];
     readonly storage?: AceBaseStorageSettings;
     readonly sponsor: boolean = false;
     readonly logColors: boolean = true;


### PR DESCRIPTION
This adds the new `socket` IPC method for easier creation of server clusters / sharing database between processes. See #83 